### PR TITLE
Encode start date parameter

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ async function makeGetRequest(url) {
 
 function buildCampsiteURL(campgroundId, startDate) {
   const adjustedStartDate = startDate.toUTC().startOf('day').toISO();
-  return `https://www.recreation.gov/api/camps/availability/campground/${campgroundId}/month?start_date=${adjustedStartDate}`;
+  const encodedStartDate = encodeURIComponent(adjustedStartDate);
+  return `https://www.recreation.gov/api/camps/availability/campground/${campgroundId}/month?start_date=${encodedStartDate}`;
 }
 
 function parseAvailabilities(availabilities) {


### PR DESCRIPTION
The `find-campsite` command currently fails with a 400
```shell
> find-campsite -c 231958
Checking for sites at ARROYO SECO available on a Friday for 2 nights.

Request failed with status code 400
```
This is due to an encoding error in the campsite request
```shell
> curl https://www.recreation.gov/api/camps/availability/campground/231958/month?start_date=2020-07-01T00:00:00.000Z
{"error":"query not encoded"}
```

We need to URL encode the `:` in the start_date parameter:
```shell
> curl https://www.recreation.gov/api/camps/availability/campground/231958/month?start_date=2020-07-01T00%3A00%3A00.000Z
{"campsites":{"70087":{"availabilities":{"2020-07-01T00:00:00Z" ....
```

Now it works ✨ 
```shell
> find-campsite -c 231958
Checking for sites at ARROYO SECO available on a Friday for 2 nights.

Found 15 matching itineraries:

...
```
