### PR TITLE
Fix issue with sequence matching logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 yarn-error.log
 dist/
+.idea/

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,15 +18,13 @@ function matchAvailableDateRanges(
 
   sortedAvailabilities.forEach((availability) => {
     if (sequenceStart) {
-      if (availability.isAvailable) {
-        if (sequenceLength < lengthOfStay) {
-          sequenceLength += 1;
-        } else {
-          const sequenceEnd = availability.date;
-          result.push({ start: sequenceStart, end: sequenceEnd });
-          sequenceStart = null;
-          sequenceLength = 0;
-        }
+      if (sequenceLength === lengthOfStay) {
+        const sequenceEnd = availability.date;
+        result.push({ start: sequenceStart, end: sequenceEnd });
+        sequenceStart = null;
+        sequenceLength = 0;
+      } else if (availability.isAvailable && sequenceLength < lengthOfStay) {
+        sequenceLength += 1;
       } else {
         sequenceStart = null;
         sequenceLength = 0;


### PR DESCRIPTION
Fixes #7

Logic was originally only matching itineraries where the end date was also available, but that's not how booking actually works.