### PR TITLE
Fix dates display for recreation.gov results

### DIFF
--- a/src/apis/recreation_gov/recreation_gov.ts
+++ b/src/apis/recreation_gov/recreation_gov.ts
@@ -37,7 +37,7 @@ class Campsite implements ICampsite {
   getAvailableDates() {
     return Object.entries(this.data.availabilities).map(([date, value]) => {
       return {
-        date: DateTime.fromISO(date),
+        date: DateTime.fromISO(date.substr(0, 19)),
         isAvailable: value === API.CampsiteAvailability.Available,
       };
     });


### PR DESCRIPTION
Recreation.gov returns dates including a timezone always set to UTC (for example: `2022-01-01T00:00:00Z`).
When displaying the date in the results, it uses local timezones, hence possibly displaying the wrong day.

This fix ignores the timezone part of the date retrieved from recreation.gov so that the timezone is the local one both for parsing and formatting.
