### PR TITLE
Add -m alias for --months cli arg

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -206,6 +206,7 @@ if (require.main === module) {
       default: 2,
     })
     .option('months', {
+      alias: 'm',
       type: 'number',
       default: 6,
       description: 'Number of months to check',


### PR DESCRIPTION
In order to keep cli arguments consistent, adds `-m` as an alias for `--months`